### PR TITLE
Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 UKHASnet-decoder
+UKHASnet-decoder.exe
 
 # Temp files
 *.swp

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Get started
 
 `./UKHASnet-decoder -h`
 
+Compiling for Windows
+-------
+It's possible to Cross Compile a windows .exe version from a Raspberry Pi (or other Linux System).
+You will need the mingw-w64 toolchain (these are different to the Mingw32 toolchain) and libraries for zlib, openssl and curl.
+Details for setting up the environment are avaialble at: https://ukhas.net/wiki/guides:rtlsdr_decoder_windows
+
 TODO (see code for details)
 -------
 - Synchronisation:

--- a/UKHASnet-decoder.c
+++ b/UKHASnet-decoder.c
@@ -261,7 +261,11 @@ int main (int argc, char**argv){
         curl_global_init(CURL_GLOBAL_ALL);
         curl = curl_easy_init();
         // send all output to /dev/null
-        devnull = fopen("/dev/null", "w+");
+#       ifdef __linux__
+            devnull = fopen("/dev/null", "w+");
+#       elif _WIN32
+            devnull = fopen("nul", "w+");
+#       endif
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, devnull);
     }
 

--- a/UKHASnet-decoder.c
+++ b/UKHASnet-decoder.c
@@ -9,6 +9,10 @@
 #include <unistd.h> // getopt
 #include <curl/curl.h>
 
+#ifdef _WIN32	// We could also use __MINGW32__
+    #include <fcntl.h>
+#endif
+
 // The identifier of this gateway
 #define GATEWAY_ID "J0"
 
@@ -157,7 +161,8 @@ bool processByte(uint8_t byte) {
                        curlbuf);
                 res = curl_easy_perform(curl);
                 if(res != CURLE_OK)
-                    printf("CURL request failed, aborting...\n");
+                    fprintf(stderr, "CURL request failed (%s)\n", curl_easy_strerror(res));
+                    //printf("CURL request failed, aborting...\n");
             }
         } else if (verbose) {
             printTime();
@@ -259,6 +264,11 @@ int main (int argc, char**argv){
         devnull = fopen("/dev/null", "w+");
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, devnull);
     }
+
+#ifdef _WIN32	// We could also use __MINGW32__
+    // Set stdin to Binary Mode
+    setmode(fileno(stdin), O_BINARY);
+#endif
 
     // Read incoming data from dongle
     while(!feof(stdin) ) {

--- a/makefile
+++ b/makefile
@@ -9,6 +9,14 @@ all: $(TARGET)
 $(TARGET): $(SOURCES)
 	$(CC) -std=gnu99 -o $(TARGET) $(SOURCES) -lcurl
 
+$(TARGET).exe: $(SOURCES)
+	i686-w64-mingw32-gcc -std=gnu99 -o $@ $^ \
+		-DCURL_STATICLIB -static \
+		-I$(HOME)/mingw/curl/include -L$(HOME)/mingw/curl/lib \
+		-L$(HOME)/mingw/openssl/lib \
+		-L$(HOME)/mingw/zlib/lib \
+		-lcurl -lssl -lcrypto -lz -lws2_32 -lgdi32
+
 clean:
 	-rm -f $(TARGET) 
 	-rm -f $(TARGET).exe


### PR DESCRIPTION
Changes to allow building a windows Executable file that can be used directly within windows (without requiring a posix layer such as cygwin). The Readme contains a wiki link for setting up a suitable environment for cross compiling.
